### PR TITLE
Bump @keplr-wallet/wc-client from 0.11.14 to 0.11.62

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@cosmjs/proto-signing": "^0.28.1",
         "@cosmjs/stargate": "^0.28.1",
         "@ethersproject/wallet": "^5.6.2",
-        "@keplr-wallet/wc-client": "^0.11.3",
+        "@keplr-wallet/wc-client": "^0.11.62",
         "@terra-money/terra.js": "^3.1.8",
         "@testing-library/jest-dom": "^5.16.2",
         "@testing-library/react": "^12.1.5",
@@ -534,74 +534,6 @@
         "@cosmjs/stream": "0.28.7",
         "xstream": "^11.14.0"
       }
-    },
-    "node_modules/@cosmjs/launchpad": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/launchpad/-/launchpad-0.24.1.tgz",
-      "integrity": "sha512-syqVGKRH6z1vw4DdAJOSu4OgUXJdkXQozqvDde0cXYwnvhb7EXGSg5CTtp+2GqTBJuNVfMZ2DSvrC2Ig8cWBQQ==",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.24.1",
-        "@cosmjs/encoding": "^0.24.1",
-        "@cosmjs/math": "^0.24.1",
-        "@cosmjs/utils": "^0.24.1",
-        "axios": "^0.21.1",
-        "fast-deep-equal": "^3.1.3"
-      }
-    },
-    "node_modules/@cosmjs/launchpad/node_modules/@cosmjs/crypto": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.24.1.tgz",
-      "integrity": "sha512-GPhaWmQO06mXldKj/b+oKF5o3jMNfRKpAw+Q8XQhrD7ItinVPDMu8Xgl6frUXWTUdgpYwqpvqOcpm85QUsYV0Q==",
-      "dependencies": {
-        "@cosmjs/encoding": "^0.24.1",
-        "@cosmjs/math": "^0.24.1",
-        "@cosmjs/utils": "^0.24.1",
-        "bip39": "^3.0.2",
-        "bn.js": "^4.11.8",
-        "elliptic": "^6.5.3",
-        "js-sha3": "^0.8.0",
-        "libsodium-wrappers": "^0.7.6",
-        "pbkdf2": "^3.1.1",
-        "ripemd160": "^2.0.2",
-        "sha.js": "^2.4.11",
-        "unorm": "^1.5.0"
-      }
-    },
-    "node_modules/@cosmjs/launchpad/node_modules/@cosmjs/encoding": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.24.1.tgz",
-      "integrity": "sha512-PMr+gaXAuM0XgjeXwB1zdX1QI0t+PgVhbmjgI/RSgswDzdExNH97qUopecL0/HG3p64vhIT/6ZjXYYTljZL7WA==",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "bech32": "^1.1.4",
-        "readonly-date": "^1.0.0"
-      }
-    },
-    "node_modules/@cosmjs/launchpad/node_modules/@cosmjs/math": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.24.1.tgz",
-      "integrity": "sha512-eBQk8twgzmpHFCVkoNjTZhsZwWRbR+JXt0FhjXJoD85SBm4K8b2OnOyTg68uPHVKOJjLRwzyRVYgMrg5TBVgwQ==",
-      "dependencies": {
-        "bn.js": "^4.11.8"
-      }
-    },
-    "node_modules/@cosmjs/launchpad/node_modules/@cosmjs/utils": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.24.1.tgz",
-      "integrity": "sha512-VA3WFx1lMFb7esp9BqHWkDgMvHoA3D9w+uDRvWhVRpUpDc7RYHxMbWExASjz+gNblTCg556WJGzF64tXnf9tdQ=="
-    },
-    "node_modules/@cosmjs/launchpad/node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
-      }
-    },
-    "node_modules/@cosmjs/launchpad/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "node_modules/@cosmjs/math": {
       "version": "0.28.7",
@@ -1515,50 +1447,6 @@
         "google-protobuf": "^3.14.0"
       }
     },
-    "node_modules/@iov/crypto": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@iov/crypto/-/crypto-2.1.0.tgz",
-      "integrity": "sha512-jnb4XuK50admolm7fBxOcxfAW2TO+wYrZlhDWiMETItY/Y5gNNa1zaDSO2wNIjjfGng+8nQ1yqnNhqy7busV2Q==",
-      "dependencies": {
-        "@iov/encoding": "^2.1.0",
-        "bip39": "^3.0.2",
-        "bn.js": "^4.11.8",
-        "elliptic": "^6.4.0",
-        "js-sha3": "^0.8.0",
-        "libsodium-wrappers": "^0.7.6",
-        "pbkdf2": "^3.0.16",
-        "ripemd160": "^2.0.2",
-        "sha.js": "^2.4.11",
-        "type-tagger": "^1.0.0",
-        "unorm": "^1.5.0"
-      }
-    },
-    "node_modules/@iov/crypto/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-    },
-    "node_modules/@iov/encoding": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@iov/encoding/-/encoding-2.1.0.tgz",
-      "integrity": "sha512-5IOdLO7Xg/uRykuiCqeMYghQ3IjWDtGxv7NTWXkgpHuna0aewx43mRpT2NPCpOZd1tpuorDtQ7/zbDNRaIIF/w==",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "bech32": "^1.1.3",
-        "bn.js": "^4.11.8",
-        "readonly-date": "^1.0.0"
-      }
-    },
-    "node_modules/@iov/encoding/node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-    },
-    "node_modules/@iov/utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@iov/utils/-/utils-2.0.2.tgz",
-      "integrity": "sha512-4D8MEvTcFc/DVy5q25vHxRItmgJyeX85dixMH+MxdKr+yy71h3sYk+sVBEIn70uqGP7VqAJkGOPNFs08/XYELw=="
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
@@ -1627,19 +1515,19 @@
       }
     },
     "node_modules/@keplr-wallet/common": {
-      "version": "0.11.14",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/common/-/common-0.11.14.tgz",
-      "integrity": "sha512-z4hAm3Fwt29zq9h3PI1fm0iqeYbnSel27y2RVx84iVkaqmqNqkfW9to244dciwVVMQnp48g8nC+wQbkvSkCxOQ==",
+      "version": "0.11.62",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/common/-/common-0.11.62.tgz",
+      "integrity": "sha512-PhXLoX+qBz9WR2/LKLf5kj1Q4pb3N5vam99lUqBiZPYf5mdtnKIvZzSO92dBMJOfMS5iRbX4Tjp6m8XhbBVeuQ==",
       "dependencies": {
-        "@keplr-wallet/crypto": "0.11.14",
+        "@keplr-wallet/crypto": "0.11.62",
         "buffer": "^6.0.3",
         "delay": "^4.4.0"
       }
     },
     "node_modules/@keplr-wallet/crypto": {
-      "version": "0.11.14",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/crypto/-/crypto-0.11.14.tgz",
-      "integrity": "sha512-YTazItU8CjKOKXVpcXECb5DLG6ht9pfth3HQvZS9zEMipY6kq5o8V4RUygcwfN90mZ5653CVlNtMjI20rwRYNA==",
+      "version": "0.11.62",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/crypto/-/crypto-0.11.62.tgz",
+      "integrity": "sha512-wRjSyf/rReGo1TEqtRkBGVS6j/DGQH9fJLAP+wbcGiq21wbn0PRlE5MPgJ8YeLa7u9iQAZEC6PlXZsDVtc7EIg==",
       "dependencies": {
         "@ethersproject/keccak256": "^5.5.0",
         "bip32": "^2.0.6",
@@ -1652,91 +1540,30 @@
       }
     },
     "node_modules/@keplr-wallet/provider": {
-      "version": "0.11.14",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/provider/-/provider-0.11.14.tgz",
-      "integrity": "sha512-PRu7co6J3TlfmhKbGhiWGKkkxMve2IJUs2fWq9POVoSu8v2nOMeCJYuGcW8WeL/dsP3eNvh/aGDaVCDEemCHNg==",
+      "version": "0.11.62",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/provider/-/provider-0.11.62.tgz",
+      "integrity": "sha512-b62OCZoGfNhtmz8IhO0wA295T1pIIg9Hqnr5p6A0ucd1k2l+wIzIYl2o0CctroM3Bk2Brv/S9HUaZCXEjIPegQ==",
       "dependencies": {
-        "@cosmjs/launchpad": "^0.24.0-alpha.25",
-        "@cosmjs/proto-signing": "^0.24.0-alpha.25",
-        "@keplr-wallet/router": "0.11.14",
-        "@keplr-wallet/types": "0.11.14",
+        "@keplr-wallet/router": "0.11.62",
+        "@keplr-wallet/types": "0.11.62",
         "buffer": "^6.0.3",
         "deepmerge": "^4.2.2",
-        "long": "^4.0.0",
-        "secretjs": "0.17.7"
-      }
-    },
-    "node_modules/@keplr-wallet/provider/node_modules/@cosmjs/proto-signing": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.24.1.tgz",
-      "integrity": "sha512-/rnyNx+FlG6b6O+igsb42eMN1/RXY+pTrNnAE8/YZaRloP9A6MXiTMO5JdYSTcjaD0mEVhejiy96bcyflKYXBg==",
-      "dependencies": {
-        "@cosmjs/launchpad": "^0.24.1",
-        "long": "^4.0.0",
-        "protobufjs": "~6.10.2"
-      }
-    },
-    "node_modules/@keplr-wallet/provider/node_modules/@types/node": {
-      "version": "13.13.52",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
-      "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ=="
-    },
-    "node_modules/@keplr-wallet/provider/node_modules/protobufjs": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.3.tgz",
-      "integrity": "sha512-yvAslS0hNdBhlSKckI4R1l7wunVilX66uvrjzE4MimiAt7/qw1nLpMhZrn/ObuUTM/c3Xnfl01LYMdcSJe6dwg==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
-        "@types/node": "^13.7.0",
         "long": "^4.0.0"
-      },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
       }
     },
     "node_modules/@keplr-wallet/router": {
-      "version": "0.11.14",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/router/-/router-0.11.14.tgz",
-      "integrity": "sha512-UH3Yy2Z7d6p9ZCdHcsVCe/PQh+MNBO/mpbZ+vQLjJu6dlQwLaUSntjZ5EPf8369QVvydZw4e70KBg+wf43ZPSA=="
+      "version": "0.11.62",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/router/-/router-0.11.62.tgz",
+      "integrity": "sha512-RE16W4tcHFZlFV+pN1mPrtKABox/MNPDytmHTSNoF9tsQJgF/+cHZkyOmpn2ceeU8Cm4vvf2r2KZSEAeg6q1Ag=="
     },
     "node_modules/@keplr-wallet/types": {
-      "version": "0.11.14",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/types/-/types-0.11.14.tgz",
-      "integrity": "sha512-oRE9YjY2dIINVzilS1f2R+GfzLNKA5qpHXp2yuS2dfXMXsm6W8L9L0rBdJgtBdLhdLnSUIEcU/yx+baot8+zMw==",
+      "version": "0.11.62",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/types/-/types-0.11.62.tgz",
+      "integrity": "sha512-u8K0jYqWFwZdPoHlgTx28F1QqSlYDIT2GoDJYfr0B3apq98WNBIAMbNwQhDtqvuBoM1yLlCmhEN+YEtygHj6XA==",
       "dependencies": {
-        "@cosmjs/launchpad": "^0.24.0-alpha.25",
-        "@cosmjs/proto-signing": "^0.24.0-alpha.25",
         "axios": "^0.27.2",
-        "long": "^4.0.0",
-        "secretjs": "0.17.7"
+        "long": "^4.0.0"
       }
-    },
-    "node_modules/@keplr-wallet/types/node_modules/@cosmjs/proto-signing": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.24.1.tgz",
-      "integrity": "sha512-/rnyNx+FlG6b6O+igsb42eMN1/RXY+pTrNnAE8/YZaRloP9A6MXiTMO5JdYSTcjaD0mEVhejiy96bcyflKYXBg==",
-      "dependencies": {
-        "@cosmjs/launchpad": "^0.24.1",
-        "long": "^4.0.0",
-        "protobufjs": "~6.10.2"
-      }
-    },
-    "node_modules/@keplr-wallet/types/node_modules/@types/node": {
-      "version": "13.13.52",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
-      "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ=="
     },
     "node_modules/@keplr-wallet/types/node_modules/axios": {
       "version": "0.27.2",
@@ -1747,86 +1574,18 @@
         "form-data": "^4.0.0"
       }
     },
-    "node_modules/@keplr-wallet/types/node_modules/protobufjs": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.3.tgz",
-      "integrity": "sha512-yvAslS0hNdBhlSKckI4R1l7wunVilX66uvrjzE4MimiAt7/qw1nLpMhZrn/ObuUTM/c3Xnfl01LYMdcSJe6dwg==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
-        "@types/node": "^13.7.0",
-        "long": "^4.0.0"
-      },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
-      }
-    },
     "node_modules/@keplr-wallet/wc-client": {
-      "version": "0.11.14",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/wc-client/-/wc-client-0.11.14.tgz",
-      "integrity": "sha512-vQSCiXL9R30RxVrOZVRJ8DbEzwf6Q8/6GEZYmioRtWgmcXxGohLBHmuITIDIEQ2pTgDKRSEv4MYu3jFEcPKk8A==",
+      "version": "0.11.62",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/wc-client/-/wc-client-0.11.62.tgz",
+      "integrity": "sha512-FfI25St+irJBegE7mDqNXxW+N/rxERINb9RdGTZ7BAyaieW6j4Ys+hp+pzO13UWNsEb+yN8vpW8G4ENWX2mfig==",
       "dependencies": {
-        "@cosmjs/launchpad": "^0.24.0-alpha.25",
-        "@cosmjs/proto-signing": "^0.24.0-alpha.25",
-        "@keplr-wallet/common": "0.11.14",
-        "@keplr-wallet/provider": "0.11.14",
-        "@keplr-wallet/types": "0.11.14",
+        "@keplr-wallet/common": "0.11.62",
+        "@keplr-wallet/provider": "0.11.62",
+        "@keplr-wallet/types": "0.11.62",
         "@walletconnect/types": "^1.6.4",
         "@walletconnect/utils": "^1.6.4",
         "buffer": "^6.0.3",
-        "deepmerge": "^4.2.2",
-        "secretjs": "0.17.7"
-      }
-    },
-    "node_modules/@keplr-wallet/wc-client/node_modules/@cosmjs/proto-signing": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.24.1.tgz",
-      "integrity": "sha512-/rnyNx+FlG6b6O+igsb42eMN1/RXY+pTrNnAE8/YZaRloP9A6MXiTMO5JdYSTcjaD0mEVhejiy96bcyflKYXBg==",
-      "dependencies": {
-        "@cosmjs/launchpad": "^0.24.1",
-        "long": "^4.0.0",
-        "protobufjs": "~6.10.2"
-      }
-    },
-    "node_modules/@keplr-wallet/wc-client/node_modules/@types/node": {
-      "version": "13.13.52",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
-      "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ=="
-    },
-    "node_modules/@keplr-wallet/wc-client/node_modules/protobufjs": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.3.tgz",
-      "integrity": "sha512-yvAslS0hNdBhlSKckI4R1l7wunVilX66uvrjzE4MimiAt7/qw1nLpMhZrn/ObuUTM/c3Xnfl01LYMdcSJe6dwg==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
-        "@types/node": "^13.7.0",
-        "long": "^4.0.0"
-      },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
+        "deepmerge": "^4.2.2"
       }
     },
     "node_modules/@lezer/common": {
@@ -4576,14 +4335,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/chrome-trace-event": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
@@ -4776,14 +4527,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/crypto-addr-codec": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/crypto-addr-codec/-/crypto-addr-codec-0.1.7.tgz",
@@ -4934,11 +4677,6 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
       "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
     },
-    "node_modules/curve25519-js": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/curve25519-js/-/curve25519-js-0.0.4.tgz",
-      "integrity": "sha512-axn2UMEnkhyDUPWOwVKBMVIzSQy2ejH2xRGy1wq81dqRwApXfIzfbE3hIX0ZRFBIihf/KDqK158DLwESu4AK1w=="
-    },
     "node_modules/debug": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
@@ -4987,9 +4725,9 @@
       "dev": true
     },
     "node_modules/deepmerge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5601,7 +5339,8 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -6093,11 +5832,6 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
-    "node_modules/is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-    },
     "node_modules/is-core-module": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
@@ -6281,65 +6015,6 @@
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
-    },
-    "node_modules/js-crypto-env": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/js-crypto-env/-/js-crypto-env-0.3.2.tgz",
-      "integrity": "sha512-F1uHiCkSOo36qBuuZABA4sBf+xeFBzhJZ0Sd7af8FAruszIhm1Xxv+Zr5Ne90Zlh7/fnxCsrdkj0N8f0a3lVlQ=="
-    },
-    "node_modules/js-crypto-hash": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/js-crypto-hash/-/js-crypto-hash-0.6.3.tgz",
-      "integrity": "sha512-SG8c9tM8y3sUb4k7WvpVfu5vU7zfPvX+eaYR5578TvehkehdaQbqAc+y+1FwxnqQ3WZ0gsYoOKp/mW+mqtNoWA==",
-      "dependencies": {
-        "buffer": "~5.4.3",
-        "hash.js": "~1.1.7",
-        "js-crypto-env": "^0.3.2",
-        "md5": "~2.2.1",
-        "sha3": "~2.1.0"
-      }
-    },
-    "node_modules/js-crypto-hash/node_modules/buffer": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
-      "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
-      "dependencies": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4"
-      }
-    },
-    "node_modules/js-crypto-hkdf": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/js-crypto-hkdf/-/js-crypto-hkdf-0.7.3.tgz",
-      "integrity": "sha512-eAaVArAjS2GCacWGXY4hjBiexrLQYlI0PMOcbwtrSEj84XU3kUfMYZm9bpTyaTXgdHC/eQoXe/Of6biG+RSEaQ==",
-      "dependencies": {
-        "js-crypto-env": "^0.3.2",
-        "js-crypto-hmac": "^0.6.3",
-        "js-crypto-random": "^0.4.3",
-        "js-encoding-utils": "0.5.6"
-      }
-    },
-    "node_modules/js-crypto-hmac": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/js-crypto-hmac/-/js-crypto-hmac-0.6.3.tgz",
-      "integrity": "sha512-T0pKOaHACOSG6Xs6/06G8RDDeZouQwIQNBq9L/zoUGsd4F67gAjpT3q2lGigAGpUd1hiyy7vnhvLpz7VDt6DbA==",
-      "dependencies": {
-        "js-crypto-env": "^0.3.2",
-        "js-crypto-hash": "^0.6.3"
-      }
-    },
-    "node_modules/js-crypto-random": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/js-crypto-random/-/js-crypto-random-0.4.3.tgz",
-      "integrity": "sha512-C3gzphPPfw9jfQ9Q/LjhJMZxQNp3AaoVRDvyZkiB+zYltfs8tKQPsskWkXACpg1Nzh01PtSRUvVijjptd2qGHQ==",
-      "dependencies": {
-        "js-crypto-env": "^0.3.2"
-      }
-    },
-    "node_modules/js-encoding-utils": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/js-encoding-utils/-/js-encoding-utils-0.5.6.tgz",
-      "integrity": "sha512-qnAGsUIWrmzh5n+3AXqbxX1KsB9hkQmJZf3aA9DLAS7GpL/NEHCBreFFbW+imramoU+Q0TDyvkwhRbBRH1TVkg=="
     },
     "node_modules/js-sdsl": {
       "version": "4.4.0",
@@ -6768,16 +6443,6 @@
       },
       "engines": {
         "node": ">= 12"
-      }
-    },
-    "node_modules/md5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
-      "integrity": "sha512-PlGG4z5mBANDGCKsYQe0CaUYHdZYZt8ZPZLmEt+Urf0W4GlpTX4HescwHU+dc9+Z/G/vZKYZYFrwgm9VxK6QOQ==",
-      "dependencies": {
-        "charenc": "~0.0.1",
-        "crypt": "~0.0.1",
-        "is-buffer": "~1.1.1"
       }
     },
     "node_modules/md5.js": {
@@ -7625,11 +7290,6 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
-    "node_modules/miscreant": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/miscreant/-/miscreant-0.3.2.tgz",
-      "integrity": "sha512-fL9KxsQz9BJB2KGPMHFrReioywkiomBiuaLk6EuChijK0BsJsIKJXdVomR+/bPj5mvbFD6wM0CM3bZio9g7OHA=="
-    },
     "node_modules/moment": {
       "version": "2.29.4",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
@@ -7792,11 +7452,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "node_modules/parcel": {
       "version": "2.7.0",
@@ -8743,42 +8398,6 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
       "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
     },
-    "node_modules/secretjs": {
-      "version": "0.17.7",
-      "resolved": "https://registry.npmjs.org/secretjs/-/secretjs-0.17.7.tgz",
-      "integrity": "sha512-j39l9+vR2A8067QBqDDejS7LmRLgdkG4uRw2Ar6HMfzDGo26eTh7cIXVlVu/yHBumxtQzKun20epOXwuYHXjQg==",
-      "dependencies": {
-        "@iov/crypto": "2.1.0",
-        "@iov/encoding": "2.1.0",
-        "@iov/utils": "2.0.2",
-        "axios": "0.21.1",
-        "curve25519-js": "0.0.4",
-        "fast-deep-equal": "3.1.1",
-        "js-crypto-hkdf": "0.7.3",
-        "miscreant": "0.3.2",
-        "pako": "1.0.11",
-        "protobufjs": "6.11.3",
-        "secure-random": "1.1.2"
-      }
-    },
-    "node_modules/secretjs/node_modules/axios": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
-      "dependencies": {
-        "follow-redirects": "^1.10.0"
-      }
-    },
-    "node_modules/secretjs/node_modules/fast-deep-equal": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
-    },
-    "node_modules/secure-random": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/secure-random/-/secure-random-1.1.2.tgz",
-      "integrity": "sha512-H2bdSKERKdBV1SwoqYm6C0y+9EA94v6SUBOWO8kDndc4NoUih7Dv6Tsgma7zO1lv27wIvjlD0ZpMQk7um5dheQ=="
-    },
     "node_modules/seedrandom": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
@@ -9229,11 +8848,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/type-tagger": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/type-tagger/-/type-tagger-1.0.0.tgz",
-      "integrity": "sha512-FIPqqpmDgdaulCnRoKv1/d3U4xVBUrYn42QXWNP3XYmgfPUDuBUsgFOb9ntT0aIe0UsUP+lknpQ5d9Kn36RssA=="
-    },
     "node_modules/typed-function": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-2.1.0.tgz",
@@ -9388,14 +9002,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unorm": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
-      "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==",
-      "engines": {
-        "node": ">= 0.4.0"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -10064,76 +9670,6 @@
         "xstream": "^11.14.0"
       }
     },
-    "@cosmjs/launchpad": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/launchpad/-/launchpad-0.24.1.tgz",
-      "integrity": "sha512-syqVGKRH6z1vw4DdAJOSu4OgUXJdkXQozqvDde0cXYwnvhb7EXGSg5CTtp+2GqTBJuNVfMZ2DSvrC2Ig8cWBQQ==",
-      "requires": {
-        "@cosmjs/crypto": "^0.24.1",
-        "@cosmjs/encoding": "^0.24.1",
-        "@cosmjs/math": "^0.24.1",
-        "@cosmjs/utils": "^0.24.1",
-        "axios": "^0.21.1",
-        "fast-deep-equal": "^3.1.3"
-      },
-      "dependencies": {
-        "@cosmjs/crypto": {
-          "version": "0.24.1",
-          "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.24.1.tgz",
-          "integrity": "sha512-GPhaWmQO06mXldKj/b+oKF5o3jMNfRKpAw+Q8XQhrD7ItinVPDMu8Xgl6frUXWTUdgpYwqpvqOcpm85QUsYV0Q==",
-          "requires": {
-            "@cosmjs/encoding": "^0.24.1",
-            "@cosmjs/math": "^0.24.1",
-            "@cosmjs/utils": "^0.24.1",
-            "bip39": "^3.0.2",
-            "bn.js": "^4.11.8",
-            "elliptic": "^6.5.3",
-            "js-sha3": "^0.8.0",
-            "libsodium-wrappers": "^0.7.6",
-            "pbkdf2": "^3.1.1",
-            "ripemd160": "^2.0.2",
-            "sha.js": "^2.4.11",
-            "unorm": "^1.5.0"
-          }
-        },
-        "@cosmjs/encoding": {
-          "version": "0.24.1",
-          "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.24.1.tgz",
-          "integrity": "sha512-PMr+gaXAuM0XgjeXwB1zdX1QI0t+PgVhbmjgI/RSgswDzdExNH97qUopecL0/HG3p64vhIT/6ZjXYYTljZL7WA==",
-          "requires": {
-            "base64-js": "^1.3.0",
-            "bech32": "^1.1.4",
-            "readonly-date": "^1.0.0"
-          }
-        },
-        "@cosmjs/math": {
-          "version": "0.24.1",
-          "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.24.1.tgz",
-          "integrity": "sha512-eBQk8twgzmpHFCVkoNjTZhsZwWRbR+JXt0FhjXJoD85SBm4K8b2OnOyTg68uPHVKOJjLRwzyRVYgMrg5TBVgwQ==",
-          "requires": {
-            "bn.js": "^4.11.8"
-          }
-        },
-        "@cosmjs/utils": {
-          "version": "0.24.1",
-          "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.24.1.tgz",
-          "integrity": "sha512-VA3WFx1lMFb7esp9BqHWkDgMvHoA3D9w+uDRvWhVRpUpDc7RYHxMbWExASjz+gNblTCg556WJGzF64tXnf9tdQ=="
-        },
-        "axios": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-          "requires": {
-            "follow-redirects": "^1.14.0"
-          }
-        },
-        "bn.js": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-        }
-      }
-    },
     "@cosmjs/math": {
       "version": "0.28.7",
       "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.28.7.tgz",
@@ -10745,54 +10281,6 @@
         "browser-headers": "^0.4.1"
       }
     },
-    "@iov/crypto": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@iov/crypto/-/crypto-2.1.0.tgz",
-      "integrity": "sha512-jnb4XuK50admolm7fBxOcxfAW2TO+wYrZlhDWiMETItY/Y5gNNa1zaDSO2wNIjjfGng+8nQ1yqnNhqy7busV2Q==",
-      "requires": {
-        "@iov/encoding": "^2.1.0",
-        "bip39": "^3.0.2",
-        "bn.js": "^4.11.8",
-        "elliptic": "^6.4.0",
-        "js-sha3": "^0.8.0",
-        "libsodium-wrappers": "^0.7.6",
-        "pbkdf2": "^3.0.16",
-        "ripemd160": "^2.0.2",
-        "sha.js": "^2.4.11",
-        "type-tagger": "^1.0.0",
-        "unorm": "^1.5.0"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-        }
-      }
-    },
-    "@iov/encoding": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@iov/encoding/-/encoding-2.1.0.tgz",
-      "integrity": "sha512-5IOdLO7Xg/uRykuiCqeMYghQ3IjWDtGxv7NTWXkgpHuna0aewx43mRpT2NPCpOZd1tpuorDtQ7/zbDNRaIIF/w==",
-      "requires": {
-        "base64-js": "^1.3.0",
-        "bech32": "^1.1.3",
-        "bn.js": "^4.11.8",
-        "readonly-date": "^1.0.0"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.12.0",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
-        }
-      }
-    },
-    "@iov/utils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@iov/utils/-/utils-2.0.2.tgz",
-      "integrity": "sha512-4D8MEvTcFc/DVy5q25vHxRItmgJyeX85dixMH+MxdKr+yy71h3sYk+sVBEIn70uqGP7VqAJkGOPNFs08/XYELw=="
-    },
     "@jridgewell/gen-mapping": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
@@ -10851,19 +10339,19 @@
       }
     },
     "@keplr-wallet/common": {
-      "version": "0.11.14",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/common/-/common-0.11.14.tgz",
-      "integrity": "sha512-z4hAm3Fwt29zq9h3PI1fm0iqeYbnSel27y2RVx84iVkaqmqNqkfW9to244dciwVVMQnp48g8nC+wQbkvSkCxOQ==",
+      "version": "0.11.62",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/common/-/common-0.11.62.tgz",
+      "integrity": "sha512-PhXLoX+qBz9WR2/LKLf5kj1Q4pb3N5vam99lUqBiZPYf5mdtnKIvZzSO92dBMJOfMS5iRbX4Tjp6m8XhbBVeuQ==",
       "requires": {
-        "@keplr-wallet/crypto": "0.11.14",
+        "@keplr-wallet/crypto": "0.11.62",
         "buffer": "^6.0.3",
         "delay": "^4.4.0"
       }
     },
     "@keplr-wallet/crypto": {
-      "version": "0.11.14",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/crypto/-/crypto-0.11.14.tgz",
-      "integrity": "sha512-YTazItU8CjKOKXVpcXECb5DLG6ht9pfth3HQvZS9zEMipY6kq5o8V4RUygcwfN90mZ5653CVlNtMjI20rwRYNA==",
+      "version": "0.11.62",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/crypto/-/crypto-0.11.62.tgz",
+      "integrity": "sha512-wRjSyf/rReGo1TEqtRkBGVS6j/DGQH9fJLAP+wbcGiq21wbn0PRlE5MPgJ8YeLa7u9iQAZEC6PlXZsDVtc7EIg==",
       "requires": {
         "@ethersproject/keccak256": "^5.5.0",
         "bip32": "^2.0.6",
@@ -10876,89 +10364,31 @@
       }
     },
     "@keplr-wallet/provider": {
-      "version": "0.11.14",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/provider/-/provider-0.11.14.tgz",
-      "integrity": "sha512-PRu7co6J3TlfmhKbGhiWGKkkxMve2IJUs2fWq9POVoSu8v2nOMeCJYuGcW8WeL/dsP3eNvh/aGDaVCDEemCHNg==",
+      "version": "0.11.62",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/provider/-/provider-0.11.62.tgz",
+      "integrity": "sha512-b62OCZoGfNhtmz8IhO0wA295T1pIIg9Hqnr5p6A0ucd1k2l+wIzIYl2o0CctroM3Bk2Brv/S9HUaZCXEjIPegQ==",
       "requires": {
-        "@cosmjs/launchpad": "^0.24.0-alpha.25",
-        "@cosmjs/proto-signing": "^0.24.0-alpha.25",
-        "@keplr-wallet/router": "0.11.14",
-        "@keplr-wallet/types": "0.11.14",
+        "@keplr-wallet/router": "0.11.62",
+        "@keplr-wallet/types": "0.11.62",
         "buffer": "^6.0.3",
         "deepmerge": "^4.2.2",
-        "long": "^4.0.0",
-        "secretjs": "0.17.7"
-      },
-      "dependencies": {
-        "@cosmjs/proto-signing": {
-          "version": "0.24.1",
-          "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.24.1.tgz",
-          "integrity": "sha512-/rnyNx+FlG6b6O+igsb42eMN1/RXY+pTrNnAE8/YZaRloP9A6MXiTMO5JdYSTcjaD0mEVhejiy96bcyflKYXBg==",
-          "requires": {
-            "@cosmjs/launchpad": "^0.24.1",
-            "long": "^4.0.0",
-            "protobufjs": "~6.10.2"
-          }
-        },
-        "@types/node": {
-          "version": "13.13.52",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
-          "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ=="
-        },
-        "protobufjs": {
-          "version": "6.10.3",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.3.tgz",
-          "integrity": "sha512-yvAslS0hNdBhlSKckI4R1l7wunVilX66uvrjzE4MimiAt7/qw1nLpMhZrn/ObuUTM/c3Xnfl01LYMdcSJe6dwg==",
-          "requires": {
-            "@protobufjs/aspromise": "^1.1.2",
-            "@protobufjs/base64": "^1.1.2",
-            "@protobufjs/codegen": "^2.0.4",
-            "@protobufjs/eventemitter": "^1.1.0",
-            "@protobufjs/fetch": "^1.1.0",
-            "@protobufjs/float": "^1.0.2",
-            "@protobufjs/inquire": "^1.1.0",
-            "@protobufjs/path": "^1.1.2",
-            "@protobufjs/pool": "^1.1.0",
-            "@protobufjs/utf8": "^1.1.0",
-            "@types/long": "^4.0.1",
-            "@types/node": "^13.7.0",
-            "long": "^4.0.0"
-          }
-        }
+        "long": "^4.0.0"
       }
     },
     "@keplr-wallet/router": {
-      "version": "0.11.14",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/router/-/router-0.11.14.tgz",
-      "integrity": "sha512-UH3Yy2Z7d6p9ZCdHcsVCe/PQh+MNBO/mpbZ+vQLjJu6dlQwLaUSntjZ5EPf8369QVvydZw4e70KBg+wf43ZPSA=="
+      "version": "0.11.62",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/router/-/router-0.11.62.tgz",
+      "integrity": "sha512-RE16W4tcHFZlFV+pN1mPrtKABox/MNPDytmHTSNoF9tsQJgF/+cHZkyOmpn2ceeU8Cm4vvf2r2KZSEAeg6q1Ag=="
     },
     "@keplr-wallet/types": {
-      "version": "0.11.14",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/types/-/types-0.11.14.tgz",
-      "integrity": "sha512-oRE9YjY2dIINVzilS1f2R+GfzLNKA5qpHXp2yuS2dfXMXsm6W8L9L0rBdJgtBdLhdLnSUIEcU/yx+baot8+zMw==",
+      "version": "0.11.62",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/types/-/types-0.11.62.tgz",
+      "integrity": "sha512-u8K0jYqWFwZdPoHlgTx28F1QqSlYDIT2GoDJYfr0B3apq98WNBIAMbNwQhDtqvuBoM1yLlCmhEN+YEtygHj6XA==",
       "requires": {
-        "@cosmjs/launchpad": "^0.24.0-alpha.25",
-        "@cosmjs/proto-signing": "^0.24.0-alpha.25",
         "axios": "^0.27.2",
-        "long": "^4.0.0",
-        "secretjs": "0.17.7"
+        "long": "^4.0.0"
       },
       "dependencies": {
-        "@cosmjs/proto-signing": {
-          "version": "0.24.1",
-          "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.24.1.tgz",
-          "integrity": "sha512-/rnyNx+FlG6b6O+igsb42eMN1/RXY+pTrNnAE8/YZaRloP9A6MXiTMO5JdYSTcjaD0mEVhejiy96bcyflKYXBg==",
-          "requires": {
-            "@cosmjs/launchpad": "^0.24.1",
-            "long": "^4.0.0",
-            "protobufjs": "~6.10.2"
-          }
-        },
-        "@types/node": {
-          "version": "13.13.52",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
-          "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ=="
-        },
         "axios": {
           "version": "0.27.2",
           "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
@@ -10967,81 +10397,21 @@
             "follow-redirects": "^1.14.9",
             "form-data": "^4.0.0"
           }
-        },
-        "protobufjs": {
-          "version": "6.10.3",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.3.tgz",
-          "integrity": "sha512-yvAslS0hNdBhlSKckI4R1l7wunVilX66uvrjzE4MimiAt7/qw1nLpMhZrn/ObuUTM/c3Xnfl01LYMdcSJe6dwg==",
-          "requires": {
-            "@protobufjs/aspromise": "^1.1.2",
-            "@protobufjs/base64": "^1.1.2",
-            "@protobufjs/codegen": "^2.0.4",
-            "@protobufjs/eventemitter": "^1.1.0",
-            "@protobufjs/fetch": "^1.1.0",
-            "@protobufjs/float": "^1.0.2",
-            "@protobufjs/inquire": "^1.1.0",
-            "@protobufjs/path": "^1.1.2",
-            "@protobufjs/pool": "^1.1.0",
-            "@protobufjs/utf8": "^1.1.0",
-            "@types/long": "^4.0.1",
-            "@types/node": "^13.7.0",
-            "long": "^4.0.0"
-          }
         }
       }
     },
     "@keplr-wallet/wc-client": {
-      "version": "0.11.14",
-      "resolved": "https://registry.npmjs.org/@keplr-wallet/wc-client/-/wc-client-0.11.14.tgz",
-      "integrity": "sha512-vQSCiXL9R30RxVrOZVRJ8DbEzwf6Q8/6GEZYmioRtWgmcXxGohLBHmuITIDIEQ2pTgDKRSEv4MYu3jFEcPKk8A==",
+      "version": "0.11.62",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/wc-client/-/wc-client-0.11.62.tgz",
+      "integrity": "sha512-FfI25St+irJBegE7mDqNXxW+N/rxERINb9RdGTZ7BAyaieW6j4Ys+hp+pzO13UWNsEb+yN8vpW8G4ENWX2mfig==",
       "requires": {
-        "@cosmjs/launchpad": "^0.24.0-alpha.25",
-        "@cosmjs/proto-signing": "^0.24.0-alpha.25",
-        "@keplr-wallet/common": "0.11.14",
-        "@keplr-wallet/provider": "0.11.14",
-        "@keplr-wallet/types": "0.11.14",
+        "@keplr-wallet/common": "0.11.62",
+        "@keplr-wallet/provider": "0.11.62",
+        "@keplr-wallet/types": "0.11.62",
         "@walletconnect/types": "^1.6.4",
         "@walletconnect/utils": "^1.6.4",
         "buffer": "^6.0.3",
-        "deepmerge": "^4.2.2",
-        "secretjs": "0.17.7"
-      },
-      "dependencies": {
-        "@cosmjs/proto-signing": {
-          "version": "0.24.1",
-          "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.24.1.tgz",
-          "integrity": "sha512-/rnyNx+FlG6b6O+igsb42eMN1/RXY+pTrNnAE8/YZaRloP9A6MXiTMO5JdYSTcjaD0mEVhejiy96bcyflKYXBg==",
-          "requires": {
-            "@cosmjs/launchpad": "^0.24.1",
-            "long": "^4.0.0",
-            "protobufjs": "~6.10.2"
-          }
-        },
-        "@types/node": {
-          "version": "13.13.52",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz",
-          "integrity": "sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ=="
-        },
-        "protobufjs": {
-          "version": "6.10.3",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.3.tgz",
-          "integrity": "sha512-yvAslS0hNdBhlSKckI4R1l7wunVilX66uvrjzE4MimiAt7/qw1nLpMhZrn/ObuUTM/c3Xnfl01LYMdcSJe6dwg==",
-          "requires": {
-            "@protobufjs/aspromise": "^1.1.2",
-            "@protobufjs/base64": "^1.1.2",
-            "@protobufjs/codegen": "^2.0.4",
-            "@protobufjs/eventemitter": "^1.1.0",
-            "@protobufjs/fetch": "^1.1.0",
-            "@protobufjs/float": "^1.0.2",
-            "@protobufjs/inquire": "^1.1.0",
-            "@protobufjs/path": "^1.1.2",
-            "@protobufjs/pool": "^1.1.0",
-            "@protobufjs/utf8": "^1.1.0",
-            "@types/long": "^4.0.1",
-            "@types/node": "^13.7.0",
-            "long": "^4.0.0"
-          }
-        }
+        "deepmerge": "^4.2.2"
       }
     },
     "@lezer/common": {
@@ -13039,11 +12409,6 @@
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
       "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="
     },
-    "charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA=="
-    },
     "chrome-trace-event": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
@@ -13209,11 +12574,6 @@
         "which": "^2.0.1"
       }
     },
-    "crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow=="
-    },
     "crypto-addr-codec": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/crypto-addr-codec/-/crypto-addr-codec-0.1.7.tgz",
@@ -13332,11 +12692,6 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
       "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
     },
-    "curve25519-js": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/curve25519-js/-/curve25519-js-0.0.4.tgz",
-      "integrity": "sha512-axn2UMEnkhyDUPWOwVKBMVIzSQy2ejH2xRGy1wq81dqRwApXfIzfbE3hIX0ZRFBIihf/KDqK158DLwESu4AK1w=="
-    },
     "debug": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
@@ -13370,9 +12725,9 @@
       "dev": true
     },
     "deepmerge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="
     },
     "define-properties": {
       "version": "1.1.3",
@@ -13836,7 +13191,8 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -14172,11 +13528,6 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
-    "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-    },
     "is-core-module": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
@@ -14309,67 +13660,6 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.5.1.tgz",
       "integrity": "sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw=="
-    },
-    "js-crypto-env": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/js-crypto-env/-/js-crypto-env-0.3.2.tgz",
-      "integrity": "sha512-F1uHiCkSOo36qBuuZABA4sBf+xeFBzhJZ0Sd7af8FAruszIhm1Xxv+Zr5Ne90Zlh7/fnxCsrdkj0N8f0a3lVlQ=="
-    },
-    "js-crypto-hash": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/js-crypto-hash/-/js-crypto-hash-0.6.3.tgz",
-      "integrity": "sha512-SG8c9tM8y3sUb4k7WvpVfu5vU7zfPvX+eaYR5578TvehkehdaQbqAc+y+1FwxnqQ3WZ0gsYoOKp/mW+mqtNoWA==",
-      "requires": {
-        "buffer": "~5.4.3",
-        "hash.js": "~1.1.7",
-        "js-crypto-env": "^0.3.2",
-        "md5": "~2.2.1",
-        "sha3": "~2.1.0"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "5.4.3",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
-          "integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
-          }
-        }
-      }
-    },
-    "js-crypto-hkdf": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/js-crypto-hkdf/-/js-crypto-hkdf-0.7.3.tgz",
-      "integrity": "sha512-eAaVArAjS2GCacWGXY4hjBiexrLQYlI0PMOcbwtrSEj84XU3kUfMYZm9bpTyaTXgdHC/eQoXe/Of6biG+RSEaQ==",
-      "requires": {
-        "js-crypto-env": "^0.3.2",
-        "js-crypto-hmac": "^0.6.3",
-        "js-crypto-random": "^0.4.3",
-        "js-encoding-utils": "0.5.6"
-      }
-    },
-    "js-crypto-hmac": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/js-crypto-hmac/-/js-crypto-hmac-0.6.3.tgz",
-      "integrity": "sha512-T0pKOaHACOSG6Xs6/06G8RDDeZouQwIQNBq9L/zoUGsd4F67gAjpT3q2lGigAGpUd1hiyy7vnhvLpz7VDt6DbA==",
-      "requires": {
-        "js-crypto-env": "^0.3.2",
-        "js-crypto-hash": "^0.6.3"
-      }
-    },
-    "js-crypto-random": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/js-crypto-random/-/js-crypto-random-0.4.3.tgz",
-      "integrity": "sha512-C3gzphPPfw9jfQ9Q/LjhJMZxQNp3AaoVRDvyZkiB+zYltfs8tKQPsskWkXACpg1Nzh01PtSRUvVijjptd2qGHQ==",
-      "requires": {
-        "js-crypto-env": "^0.3.2"
-      }
-    },
-    "js-encoding-utils": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/js-encoding-utils/-/js-encoding-utils-0.5.6.tgz",
-      "integrity": "sha512-qnAGsUIWrmzh5n+3AXqbxX1KsB9hkQmJZf3aA9DLAS7GpL/NEHCBreFFbW+imramoU+Q0TDyvkwhRbBRH1TVkg=="
     },
     "js-sdsl": {
       "version": "4.4.0",
@@ -14627,16 +13917,6 @@
         "seedrandom": "^3.0.5",
         "tiny-emitter": "^2.1.0",
         "typed-function": "^2.1.0"
-      }
-    },
-    "md5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
-      "integrity": "sha512-PlGG4z5mBANDGCKsYQe0CaUYHdZYZt8ZPZLmEt+Urf0W4GlpTX4HescwHU+dc9+Z/G/vZKYZYFrwgm9VxK6QOQ==",
-      "requires": {
-        "charenc": "~0.0.1",
-        "crypt": "~0.0.1",
-        "is-buffer": "~1.1.1"
       }
     },
     "md5.js": {
@@ -15177,11 +14457,6 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
-    "miscreant": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/miscreant/-/miscreant-0.3.2.tgz",
-      "integrity": "sha512-fL9KxsQz9BJB2KGPMHFrReioywkiomBiuaLk6EuChijK0BsJsIKJXdVomR+/bPj5mvbFD6wM0CM3bZio9g7OHA=="
-    },
     "moment": {
       "version": "2.29.4",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
@@ -15306,11 +14581,6 @@
       "requires": {
         "p-limit": "^3.0.2"
       }
-    },
-    "pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "parcel": {
       "version": "2.7.0",
@@ -16039,44 +15309,6 @@
         }
       }
     },
-    "secretjs": {
-      "version": "0.17.7",
-      "resolved": "https://registry.npmjs.org/secretjs/-/secretjs-0.17.7.tgz",
-      "integrity": "sha512-j39l9+vR2A8067QBqDDejS7LmRLgdkG4uRw2Ar6HMfzDGo26eTh7cIXVlVu/yHBumxtQzKun20epOXwuYHXjQg==",
-      "requires": {
-        "@iov/crypto": "2.1.0",
-        "@iov/encoding": "2.1.0",
-        "@iov/utils": "2.0.2",
-        "axios": "0.21.1",
-        "curve25519-js": "0.0.4",
-        "fast-deep-equal": "3.1.1",
-        "js-crypto-hkdf": "0.7.3",
-        "miscreant": "0.3.2",
-        "pako": "1.0.11",
-        "protobufjs": "6.11.3",
-        "secure-random": "1.1.2"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "0.21.1",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-          "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
-          "requires": {
-            "follow-redirects": "^1.10.0"
-          }
-        },
-        "fast-deep-equal": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
-        }
-      }
-    },
-    "secure-random": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/secure-random/-/secure-random-1.1.2.tgz",
-      "integrity": "sha512-H2bdSKERKdBV1SwoqYm6C0y+9EA94v6SUBOWO8kDndc4NoUih7Dv6Tsgma7zO1lv27wIvjlD0ZpMQk7um5dheQ=="
-    },
     "seedrandom": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
@@ -16413,11 +15645,6 @@
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true
     },
-    "type-tagger": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/type-tagger/-/type-tagger-1.0.0.tgz",
-      "integrity": "sha512-FIPqqpmDgdaulCnRoKv1/d3U4xVBUrYn42QXWNP3XYmgfPUDuBUsgFOb9ntT0aIe0UsUP+lknpQ5d9Kn36RssA=="
-    },
     "typed-function": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-2.1.0.tgz",
@@ -16520,11 +15747,6 @@
         "@types/unist": "^2.0.0",
         "unist-util-is": "^5.0.0"
       }
-    },
-    "unorm": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.6.0.tgz",
-      "integrity": "sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA=="
     },
     "update-browserslist-db": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@cosmjs/proto-signing": "^0.28.1",
     "@cosmjs/stargate": "^0.28.1",
     "@ethersproject/wallet": "^5.6.2",
-    "@keplr-wallet/wc-client": "^0.11.3",
+    "@keplr-wallet/wc-client": "^0.11.62",
     "@terra-money/terra.js": "^3.1.8",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.5",


### PR DESCRIPTION
Bumps @keplr-wallet/wc-client from 0.11.14 to 0.11.62.

---
updated-dependencies:
- dependency-name: "@keplr-wallet/wc-client" dependency-type: direct:production update-type: version-update:semver-patch ...